### PR TITLE
Add analytics scripts and SEO metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,24 +2,115 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-P5S3QBB');</script>
+    <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-KH45Q8QETD"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-KH45Q8QETD');
+    </script>
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "ofcmc03ke0");
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OECL</title>
     <meta name="description" content="OECL - Reliable and efficient logistics solutions tailored to your business needs." />
     <meta name="author" content="OECL" />
 
-    <meta property="og:title" content="OECL - Logistics & Transportation" />
-    <meta property="og:description" content="Reliable and efficient logistics solutions tailored to your business needs." />
+    <meta property="og:title" content="OECL Shipping and Logistics Company in Singapore" />
+    <meta property="og:site_name" content="OECL (Singapore) Pte Ltd. - Shipping and Logistics Company" />
+    <meta property="og:url" content="https://www.oecl.sg/" />
+    <meta property="og:description" content="OECL is a trusted logistics company in Singapore offering comprehensive freight and warehousing solutions. Contact us for efficient logistics services tailored to your needs." />
     <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://www.oecl.sg/lovable-uploads/80ac017b-3e55-468b-9c72-9730b97cdcb0.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@oecl" />
     <meta name="twitter:image" content="" />
-    
+
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+
+    <script type="application/ld+json">
+    {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Oecl",
+    "url": " https://www.oecl.sg/home",
+    "logo": " https://www.oecl.sg/lovable-uploads/80ac017b-3e55-468b-9c72-9730b97cdcb0.png",
+    "contactPoint": [{
+    "@type": "ContactPoint",
+    "telephone": "+6562241338",
+    "contactType": "customer service",
+    "areaServed": "SG",
+    "availableLanguage": "en"
+    },{
+    "@type": "ContactPoint",
+    "telephone": "+6562241336",
+    "contactType": "customer service",
+    "areaServed": "SG",
+    "availableLanguage": "en"
+    }],
+    "sameAs": [
+    "https://www.facebook.com/oeclsingapore",
+    "https://twitter.com/oeclsg",
+    "https://www.instagram.com/oecl_logistics/?hl=en",
+    "https://www.linkedin.com/company/oecl/"
+    ]
+    }
+    </script>
+
+    <script type="application/ld+json">
+    {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "OECL (Singapore) Pte Ltd. - Shipping and Logistics Company",
+    "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "Blk 511 Kampong Bahru Rd, #03-01Keppel, Distripark 099447",
+    "addressLocality": "Singapore",
+    "addressRegion": "SG",
+    "postalCode": "099447"
+    },
+    "image": " https://www.oecl.sg/lovable-uploads/80ac017b-3e55-468b-9c72-9730b97cdcb0.png",
+    "email": "info@oecl.sg",
+    "telephone": "+65 6224 1338",
+    "url": "https://www.oecl.sg/",
+    "openingHours": "Mo,Tu,We,Th,Fr,Sa,Su 08:00-06:00",
+    "openingHoursSpecification": [ {
+
+    "@type": "OpeningHoursSpecification",
+    "dayOfWeek": [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday"
+    ],
+    "opens": "08:00",
+    "closes": "06:00"
+    } ],
+    "priceRange":"$"
+
+    }
+    </script>
   </head>
 
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P5S3QBB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+
+interface SEOProps {
+  title: string;
+  description: string;
+  keywords: string;
+  url: string;
+}
+
+const SEO = ({ title, description, keywords, url }: SEOProps) => {
+  useEffect(() => {
+    document.title = title;
+
+    const setMeta = (name: string, content: string) => {
+      let element = document.querySelector(`meta[name="${name}"]`) as HTMLMetaElement | null;
+      if (!element) {
+        element = document.createElement("meta");
+        element.setAttribute("name", name);
+        document.head.appendChild(element);
+      }
+      element.setAttribute("content", content);
+    };
+
+    setMeta("description", description);
+    setMeta("keywords", keywords);
+
+    let link = document.querySelector("link[rel='canonical']") as HTMLLinkElement | null;
+    if (!link) {
+      link = document.createElement("link");
+      link.setAttribute("rel", "canonical");
+      document.head.appendChild(link);
+    }
+    link.setAttribute("href", url);
+  }, [title, description, keywords, url]);
+
+  return null;
+};
+
+export default SEO;

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -7,6 +7,7 @@ import { Pagination, PaginationContent, PaginationItem, PaginationLink, Paginati
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import { supabase } from "@/integrations/supabase/client";
+import SEO from '@/components/SEO';
 const ScrollToTop = () => {
   const {
     pathname
@@ -82,6 +83,12 @@ const Blog = () => {
   return <div className="min-h-screen bg-background">
       <ScrollToTop />
       <Navigation />
+      <SEO
+        title="OECL Logistics Blog | Expert Insights for B2B Supply Chain Solutions"
+        description="Explore OECL's logistics blog for B2B-focused articles on warehousing, customs clearance, project cargo, and more. Stay informed with expert insights to optimize your supply chain operations."
+        keywords="B2B logistics blog, supply chain insights, warehousing solutions, customs clearance tips, project cargo logistics, OECL Singapore, logistics industry news, freight forwarding updates, supply chain optimization"
+        url="https://www.oecl.sg/blogs"
+      />
       <div className="container mx-auto px-4 py-12 pt-24">
         <div className="text-center mb-12">
           <h1 className="text-4xl md:text-5xl font-bold mb-4 text-foreground">Our Blog</h1>

--- a/src/pages/GlobalPresence.tsx
+++ b/src/pages/GlobalPresence.tsx
@@ -6,6 +6,7 @@ import ContactMapContainer from '@/components/ContactMapContainer';
 import ContactSidebar from '@/components/ContactSidebar';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { motion } from 'framer-motion';
+import SEO from '@/components/SEO';
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
@@ -39,6 +40,12 @@ const GlobalPresence = () => {
     <div className="min-h-screen flex flex-col bg-gradient-to-b from-amber-50/30 to-white">
       <ScrollToTop />
       <Navigation />
+      <SEO
+        title="OECL Global Presence | International Logistics Solutions"
+        description="Explore OECL's extensive global presence, offering comprehensive logistics and supply chain solutions across key markets. Our strategic network ensures seamless operations for your business worldwide."
+        keywords="OECL global logistics, international supply chain solutions, global logistics network, OECL worldwide presence, B2B logistics services, global freight forwarding, international warehousing services, OECL supply chain partners"
+        url="https://www.oecl.sg/global-presence"
+      />
 
       <motion.div
         initial={{ opacity: 0 }}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
+import SEO from "@/components/SEO";
 import HeroSection from "@/components/HeroSection";
 import TrackOrder from "@/components/TrackOrder";
 import ServicesCards from "@/components/ServicesCards";
@@ -56,6 +57,12 @@ const Index = () => {
 
   return (
     <div className="bg-white">
+      <SEO
+        title="OECL Singapore | Global Logistics & Supply Chain Solutions"
+        description="OECL is a premier global logistics and supply chain partner, offering end-to-end solutions including warehousing, freight forwarding, customs clearance, and project cargo services. With a presence across Southeast Asia, South Asia, the Middle East, and select Western countries, we deliver reliable, efficient, and tech-driven logistics solutions tailored to your business needs."
+        keywords="B2B logistics Singapore, global supply chain solutions, warehousing services, freight forwarding, customs clearance, project cargo, OECL logistics, international logistics partner, supply chain optimization"
+        url="https://www.oecl.sg/home"
+      />
       <Navigation />
       <ScrollToTop />
       <HeroSection />

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
+import SEO from '@/components/SEO';
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
@@ -21,6 +22,12 @@ const PrivacyPolicy = () => {
     <div className="min-h-screen bg-white">
       <ScrollToTop />
       <Navigation />
+      <SEO
+        title="Privacy Policy | OECL Singapore Logistics"
+        description="OECL Singapore is committed to protecting your privacy. Our Privacy Policy outlines how we collect, use, disclose, and safeguard your information when you visit our website and use our services. We ensure compliance with applicable data protection laws to maintain the confidentiality and security of your personal data."
+        keywords="OECL privacy policy, data protection Singapore, logistics company privacy, personal data security, OECL data collection, privacy compliance, business data protection, logistics service provider privacy policy"
+        url="https://www.oecl.sg/privacy-policy"
+      />
       
       <div className="container mx-auto px-4 py-12 pt-24 max-w-4xl">
         <div className="prose prose-lg max-w-none text-black">

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -3,6 +3,7 @@ import { useLocation, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import {
   Truck, Plane, Ship, Box, UserCheck, Container, Cuboid
 } from "lucide-react";
@@ -176,6 +177,12 @@ const Services: React.FC = () => {
     <div className="min-h-screen flex flex-col bg-white">
       <ScrollToTop />
       <Navigation />
+      <SEO
+        title="Comprehensive B2B Logistics Services | OECL Singapore"
+        description="OECL offers end-to-end logistics solutions for businesses, including warehousing, air and ocean freight forwarding, customs clearance, liner agency, liquid cargo transportation, consolidation, project cargo, and 3PL services. Our expertise ensures efficient and reliable supply chain management tailored to your business needs."
+        keywords="B2B logistics Singapore, warehousing services, air freight forwarding, ocean freight forwarding, customs clearance, liner agency, liquid cargo transportation, consolidation services, project cargo logistics, 3PL services, OECL logistics"
+        url="https://www.oecl.sg/services"
+      />
       <main className="flex-grow pt-20">
         {/* Hero Section */}
         <section className="bg-gradient-to-r from-black via-gray-900 to-black text-white relative overflow-hidden">

--- a/src/pages/TermsAndConditions.tsx
+++ b/src/pages/TermsAndConditions.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
+import SEO from '@/components/SEO';
 
 const ScrollToTop = () => {
   const { pathname } = useLocation();
@@ -21,6 +22,12 @@ const TermsAndConditions = () => {
     <div className="min-h-screen bg-white">
       <ScrollToTop />
       <Navigation />
+      <SEO
+        title="Terms and Conditions | OECL Singapore Logistics"
+        description="Review OECL Singapore's Terms and Conditions to understand the legal framework governing the use of our logistics services, including warehousing, freight forwarding, customs clearance, and more. Ensure compliance and clarity in our business engagements."
+        keywords="OECL terms and conditions, logistics service agreement, Singapore logistics terms, freight forwarding terms, warehousing service terms, customs clearance agreement, B2B logistics contract"
+        url="https://www.oecl.sg/terms-and-conditions"
+      />
       
       <div className="container mx-auto px-4 py-12 pt-24 max-w-4xl">
         <div className="prose prose-lg max-w-none text-black">

--- a/src/pages/aboutus.tsx
+++ b/src/pages/aboutus.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { Truck, Ship, Globe, Users, Award, TrendingUp, CheckCircle, Star } from "lucide-react";
 const ScrollToTop = () => {
   const {
@@ -39,6 +40,12 @@ const AboutUs = () => {
   return <div className="bg-black text-white min-h-screen flex flex-col">
       <ScrollToTop />
       <Navigation />
+      <SEO
+        title="About OECL Singapore | Leading Global Logistics & Supply Chain Partner"
+        description="OECL is a premier global logistics and supply chain partner headquartered in Singapore. Established in 2008 by a team of experienced professionals, we offer end-to-end solutions across warehousing, freight forwarding, customs clearance, and more. Our strategic presence in key markets ensures seamless operations for your business worldwide."
+        keywords="OECL Singapore, global logistics partner, supply chain solutions, warehousing services, freight forwarding, customs clearance, project cargo, B2B logistics, international logistics, supply chain optimization"
+        url="https://www.oecl.sg/about-us"
+      />
       <main className="flex-grow pt-20">
         {/* Hero Section */}
         <section className="py-20 relative overflow-hidden">

--- a/src/pages/services/AirFreight.tsx
+++ b/src/pages/services/AirFreight.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Plane, Clock, Globe, Shield, CheckCircle } from "lucide-react";
 
@@ -21,6 +22,12 @@ const AirFreight = () => {
   return (
     <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Air Freight Services | OECL Global Cargo Solutions"
+        description="OECL offers fast, reliable B2B air freight services for global businesses. Secure, time-critical cargo solutions with end-to-end logistics support."
+        keywords="B2B air freight services, business cargo solutions, corporate air shipping, international air freight logistics, global cargo transport, air freight forwarding"
+        url="https://www.oecl.sg/services/air-freight"
+      />
 
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/Consolidation.tsx
+++ b/src/pages/services/Consolidation.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Cuboid } from "lucide-react";
 
@@ -12,6 +13,12 @@ const Consolidation = () => {
   return (
     <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Cargo Consolidation Services in Singapore | OECL Logistics"
+        description="OECL offers efficient B2B cargo consolidation services in Singapore, combining smaller shipments into full container loads (FCL) to reduce costs and improve shipping efficiency."
+        keywords="B2B cargo consolidation Singapore, LCL consolidation services, cost-effective shipping solutions, OECL consolidation logistics, freight consolidation Singapore, FCL shipping for businesses, supply chain optimization, logistics consolidation services"
+        url="https://www.oecl.sg/services/consolidation"
+      />
 
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/CustomsClearance.tsx
+++ b/src/pages/services/CustomsClearance.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { UserCheck, FileText, Shield, Globe, CheckCircle } from "lucide-react";
 const CustomsClearance = () => {
@@ -10,6 +11,12 @@ const CustomsClearance = () => {
   const features = ["Import/Export documentation", "Duty & tax calculation", "Compliance management", "Certificate handling", "Government liaison", "Fast clearance processing"];
   return <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Customs Clearance Services in Singapore | OECL Logistics"
+        description="OECL offers expert customs clearance solutions for businesses in Singapore, ensuring seamless import and export compliance, accurate documentation, and efficient handling of trade procedures."
+        keywords="B2B customs clearance Singapore, business import/export services, trade compliance logistics, OECL customs solutions, Singapore customs brokers, commercial customs clearance, logistics documentation support, B2B logistics Singapore"
+        url="https://www.oecl.sg/services/customs-clearance"
+      />
       
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/LinerAgency.tsx
+++ b/src/pages/services/LinerAgency.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Container } from "lucide-react";
 
@@ -12,6 +13,12 @@ const LinerAgency = () => {
   return (
     <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Liner Agency Services in Singapore | OECL Logistics"
+        description="OECL offers comprehensive B2B liner agency services in Singapore, including vessel scheduling, documentation, customs clearance, cargo booking, and port coordination to streamline your shipping operations."
+        keywords="B2B liner agency Singapore, vessel scheduling services, shipping documentation support, customs clearance logistics, cargo booking services, port coordination Singapore, OECL liner agency, business shipping solutions, commercial liner services, logistics for businesses"
+        url="https://www.oecl.sg/services/liner-agency"
+      />
 
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/LiquidCargo.tsx
+++ b/src/pages/services/LiquidCargo.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Truck, Droplets, Shield, CheckCircle } from "lucide-react";
 const LiquidCargo = () => {
@@ -10,6 +11,12 @@ const LiquidCargo = () => {
   const features = ["Specialized tank transportation", "Temperature-controlled transport", "Hazardous material handling", "ISO tank containers", "Safety compliance", "Real-time monitoring"];
   return <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Liquid Cargo Transportation Services | OECL Singapore"
+        description="OECL offers specialized B2B liquid cargo transportation solutions in Singapore, utilizing ISO Tanks, Flexi Tanks, and IBCs for safe and efficient handling of hazardous and non-hazardous liquids."
+        keywords="B2B liquid cargo Singapore, liquid cargo transportation, hazardous liquid logistics, non-hazardous liquid shipping, ISO tank transport, Flexi tank logistics, IBC liquid transport, chemical logistics Singapore, bulk liquid shipping, OECL liquid cargo"
+        url="https://www.oecl.sg/services/liquid-cargo"
+      />
       
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/OceanFreight.tsx
+++ b/src/pages/services/OceanFreight.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Ship } from "lucide-react";
 
@@ -21,6 +22,12 @@ const OceanFreight = () => {
   return (
     <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Ocean Freight Services | OECL Global Shipping Solutions"
+        description="OECL provides reliable B2B ocean freight services for businesses worldwide—offering FCL, LCL, chartering, and seamless port-to-port logistics solutions."
+        keywords="B2B ocean freight services, full container shipping, LCL cargo forwarding, ocean freight solutions, global shipping for businesses, FCL LCL ocean transport"
+        url="https://www.oecl.sg/services/ocean-freight"
+      />
 
       {/* Hero Section */}
       <section className="pt-28 pb-16 relative overflow-hidden">

--- a/src/pages/services/ProjectCargo.tsx
+++ b/src/pages/services/ProjectCargo.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Box, Package, Database, BarChart3, CheckCircle } from "lucide-react";
 const ProjectCargo = () => {
@@ -10,6 +11,12 @@ const ProjectCargo = () => {
   const features = ["Advanced WMS system", "Temperature-controlled storage", "Inventory management", "Order fulfillment", "Pick & pack services", "Real-time reporting"];
   return <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B Project Cargo Services in Singapore | OECL Logistics"
+        description="OECL offers specialized B2B project cargo services in Singapore, handling oversized, heavy-lift, and complex shipments with precision and efficiency. Our team ensures seamless coordination for your project's logistics needs."
+        keywords="B2B project cargo Singapore, heavy-lift logistics, oversized cargo transportation, complex project shipments, OECL project cargo, project logistics services, Singapore project cargo solutions, industrial cargo handling, project cargo coordination"
+        url="https://www.oecl.sg/services/project-cargo"
+      />
 
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/ThirdPartyLogistics.tsx
+++ b/src/pages/services/ThirdPartyLogistics.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Box } from "lucide-react";
 
@@ -12,6 +13,12 @@ const ThirdPartyLogistics = () => {
   return (
     <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="B2B 3PL Services in Singapore | OECL Logistics"
+        description="OECL offers comprehensive B2B 3PL services in Singapore, including warehousing, fulfillment, transportation, and reverse logistics, to streamline your supply chain operations."
+        keywords="B2B 3PL Singapore, third-party logistics services, supply chain management, warehousing solutions, fulfillment services, transportation logistics, reverse logistics, OECL 3PL"
+        url="https://www.oecl.sg/services/3pl"
+      />
 
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>

--- a/src/pages/services/Warehousing.tsx
+++ b/src/pages/services/Warehousing.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import SEO from "@/components/SEO";
 import { motion } from "framer-motion";
 import { Box, Package, Database, BarChart3, CheckCircle } from "lucide-react";
 const Warehousing = () => {
@@ -10,6 +11,12 @@ const Warehousing = () => {
   const features = ["Advanced WMS system", "Temperature-controlled storage", "Inventory management", "Order fulfillment", "Pick & pack services", "Real-time reporting"];
   return <div className="bg-white text-black min-h-screen">
       <Navigation />
+      <SEO
+        title="Efficient B2B Warehousing Solutions | OECL Singapore Logistics Services"
+        description="OECL offers tailored B2B warehousing solutions in Singapore, including inventory management, cold storage, container vanning, and distribution services to streamline your supply chain and boost business efficiency."
+        keywords="B2B warehousing Singapore, business warehousing solutions, inventory management services, cold storage logistics, container vanning Singapore, supply chain warehousing, OECL warehousing, logistics for businesses, B2B logistics services, warehouse storage for companies"
+        url="https://www.oecl.sg/services/warehousing"
+      />
       
       <section className="pt-28 pb-16 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-red-600/20 to-transparent"></div>


### PR DESCRIPTION
## Summary
- integrate Google Tag Manager, Analytics, Microsoft Clarity, and Facebook OG tags in `index.html`
- add structured data for organization and local business
- implement reusable `SEO` component and apply descriptive meta tags across site pages

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1762f9c083309bf1e41df417ce6b